### PR TITLE
wcコマンドのプログラムを作成

### DIFF
--- a/01.fizzbuzz/fizzbuzz.rb
+++ b/01.fizzbuzz/fizzbuzz.rb
@@ -1,13 +1,11 @@
-# frozen_string_literal: true
-
 (1..20).each do |n|
-  if (n % 15).zero?
+  if n % 15 == 0
     puts 'FizzBuzz'
-  elsif (n % 5).zero?
+  elsif n % 5 == 0
     puts 'Buzz'
-  elsif (n % 3).zero?
+  elsif n % 3 == 0
     puts 'Fizz'
-  else
+  else 
     puts n
   end
 end

--- a/01.fizzbuzz/fizzbuzz.rb
+++ b/01.fizzbuzz/fizzbuzz.rb
@@ -1,11 +1,13 @@
+# frozen_string_literal: true
+
 (1..20).each do |n|
-  if n % 15 == 0
+  if (n % 15).zero?
     puts 'FizzBuzz'
-  elsif n % 5 == 0
+  elsif (n % 5).zero?
     puts 'Buzz'
-  elsif n % 3 == 0
+  elsif (n % 3).zero?
     puts 'Fizz'
-  else 
+  else
     puts n
   end
 end

--- a/05.ls/ls.rb
+++ b/05.ls/ls.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require 'optparse'
+require 'etc'
+
+# オプション設定処理
+option = {}
+
+OptionParser.new do |opt|
+  opt.on('-a') { |v| option[:a] = v }
+  opt.on('-r') { |v| option[:r] = v }
+  opt.on('-l') { |v| option[:l] = v }
+
+  opt.parse!(ARGV)
+end
+
+# 出力内容加工処理
+# オプションに応じて処理
+file_names = Dir.glob('*').sort
+file_names = Dir.entries('.').sort if option[:a]
+file_names = file_names.reverse if option[:r]
+
+# -lオプションがある場合の処理
+# 8進数のアクセス権を文字に直す処理
+def convert_into_character(num_of_permission)
+  case num_of_permission.to_i
+  # 各8進数の数字と対応する権限を代入
+  when 0
+    '---'
+  when 1
+    '--x'
+  when 2
+    '-w-'
+  when 3
+    '-wx'
+  when 4
+    'r--'
+  when 5
+    'r-x'
+  when 6
+    'rw-'
+  when 7
+    'rwx'
+  end
+end
+
+file_details = [] # 各ファイルの詳細情報格納配列
+nums_of_file_blocks = [] # 各ファイルの割り当てブロック数格納配列
+if option[:l]
+  # 対象のファイルが入った配列をeachで処理
+  file_names.each do |file|
+    file_info = [] # 各ファイルの情報結合用配列
+    stat = File.stat(file)
+    # ファイルタイプを取得
+    ftype = stat.ftype
+    file_info <<
+      case ftype
+      when 'file'
+        '-'
+      when 'fif'
+        'p'
+      else
+        ftype[0]
+      end
+
+    # モードを8進数で取得、権限部分（下3桁）を
+    file_mode = format('%o', stat.mode).slice!(-3, 3).split('')
+    # 下3桁を解析
+    file_mode.each do |permission|
+      file_info << convert_into_character(permission)
+    end
+
+    nums_of_file_blocks << stat.blocks
+    file_info << "  #{stat.nlink}"
+    file_info << " #{Etc.getpwuid(stat.uid).name}"
+    file_info << "  #{Etc.getgrgid(stat.gid).name}"
+    file_info << "  #{stat.size}"
+    file_info << " #{stat.ctime.strftime("%-m\s\s%-d\s%H:%M")}"
+    file_info << " #{file}"
+    # 各情報を一つの文字列に結合
+    file_details << file_info.join
+  end
+  puts "total #{nums_of_file_blocks.sum}"
+  puts file_details
+  return # lオプションがある時は整形出力しないため、ここで終了
+end
+
+# 出力整形処理パート
+MAX_COLUMN = 3 # 今回は上限3列が要件
+console_width = `tput cols`.to_i # ターミナルの幅を取得
+max_length = file_names.max_by(&:length).length # ファイル名の最大文字数を算出
+num_of_column = console_width / (max_length + 1) # 表示できる列数を算出(余裕を持たせるためプラス1して計算)
+num_of_column = MAX_COLUMN if num_of_column > MAX_COLUMN # 列数が上限を超えないようにする
+column_width = console_width / num_of_column # 一列あたりの幅を算出
+
+# 縦出力のための加工
+file_names << "\s" until (file_names.count % num_of_column).zero? # 整形にあたってズレが生じないよう、空白を配列に加える
+
+formated_file_names = [] # 最終出力用配列を用意
+
+num_of_lines = file_names.count / num_of_column # 表示する行数(要素数を列数で割った数)を算出
+file_names.each_slice(num_of_lines) { |v| formated_file_names << v } # 行数にeach_sliceし、最終出力用配列に格納
+formated_file_names = formated_file_names.transpose # その結果をtransposeし、出力前の配列が完成
+
+# 出力処理
+formated_file_names.each do |formated_file_name|
+  formated_file_name.each.with_index(1) do |file_name, i|
+    print file_name.ljust(column_width)
+    print "\n" if i == num_of_column # 表示する列数に合わせて改行を入れる
+  end
+end

--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'optparse'
+
+option = {}
+OptionParser.new do |opt|
+  opt.on('-l') { |v| option[:l] = v }
+
+  opt.parse!(ARGV)
+end
+
+def multi_args?
+  ARGV.count >= 2
+end
+
+if ARGV.count.positive?
+  # 引数が複数の場合は合計出力用配列を用意
+  total_info = [] if multi_args?
+
+  ARGV.each do |file_name|
+    if !Dir.entries('.').include?(file_name)
+      puts "wc: #{file_name}: open: No such file or directory"
+      next
+    elsif File.stat(file_name).ftype == 'directory'
+      puts "wc: #{file_name}: read: Is a directory"
+      next
+    end
+
+    info = []
+    str = File.read(file_name)
+    info << str.count("\n")
+
+    if option[:l]
+      info << file_name
+
+      puts info.join(' ')
+      total_info << info.slice(0) if multi_args?
+    else
+      info << str.split(/\n+|\t+\s+|[[:space:]]+/).size
+      info << File.size(file_name)
+      info << file_name
+
+      puts info.join(' ')
+      total_info << info.slice(0..-2) if multi_args?
+    end
+  end
+
+  # 引数が複数ある場合は最後にトータルを出力
+  if multi_args?
+    if option[:l]
+      puts "#{total_info.sum} total"
+      return
+    end
+
+    total_info = total_info.transpose.map(&:sum) << 'total'
+    puts total_info.join(' ')
+  end
+  return
+end
+
+# 引数がない場合に、コマンドの実行結果を受け取って処理する
+str = readlines
+info = []
+if option[:l]
+  puts str.count
+else
+  info << str.count
+  amounts_of_words = str.map { |line| line.split(/\n+|\t+\s+|[[:space:]]+/).size }
+  info << amounts_of_words.sum
+  info << str.join.bytesize
+
+  puts info.join(' ')
+end

--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -47,15 +47,14 @@ if ARGV.count.positive?
     if option[:l]
       info << file_name
 
-      puts info.join(' ')
       info_for_total << info.slice(0) if multi_args?
     else
       info << amount_of_words(str)
       info << File.size(file_name) << file_name
 
-      puts info.join(' ')
       info_for_total << info.slice(0..-2) if multi_args?
     end
+    puts info.join(' ')
   end
 
   # 引数が複数ある場合は最後にトータルを出力

--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -13,9 +13,23 @@ def multi_args?
   ARGV.count >= 2
 end
 
+def total_info(info_for_total, option_l = nil)
+  if option_l
+    puts "#{info_for_total.sum} total"
+    return
+  end
+
+  info_for_total = info_for_total.transpose.map(&:sum) << 'total'
+  puts info_for_total.join(' ')
+end
+
+def amount_of_words(str)
+  str.split(/\n+|\t+\s+|[[:space:]]+/).size
+end
+
 if ARGV.count.positive?
   # 引数が複数の場合は合計出力用配列を用意
-  total_info = [] if multi_args?
+  info_for_total = [] if multi_args?
 
   ARGV.each do |file_name|
     if !Dir.entries('.').include?(file_name)
@@ -34,27 +48,18 @@ if ARGV.count.positive?
       info << file_name
 
       puts info.join(' ')
-      total_info << info.slice(0) if multi_args?
+      info_for_total << info.slice(0) if multi_args?
     else
-      info << str.split(/\n+|\t+\s+|[[:space:]]+/).size
-      info << File.size(file_name)
-      info << file_name
+      info << amount_of_words(str)
+      info << File.size(file_name) << file_name
 
       puts info.join(' ')
-      total_info << info.slice(0..-2) if multi_args?
+      info_for_total << info.slice(0..-2) if multi_args?
     end
   end
 
   # 引数が複数ある場合は最後にトータルを出力
-  if multi_args?
-    if option[:l]
-      puts "#{total_info.sum} total"
-      return
-    end
-
-    total_info = total_info.transpose.map(&:sum) << 'total'
-    puts total_info.join(' ')
-  end
+  total_info(info_for_total, option[:l]) if multi_args?
   return
 end
 
@@ -65,7 +70,7 @@ if option[:l]
   puts str.count
 else
   info << str.count
-  amounts_of_words = str.map { |line| line.split(/\n+|\t+\s+|[[:space:]]+/).size }
+  amounts_of_words = str.map { |line| amount_of_words(line) }
   info << amounts_of_words.sum
   info << str.join.bytesize
 


### PR DESCRIPTION
該当プラクティスは[こちら](https://bootcamp.fjord.jp/practices/161)です。

## 内容
- [x] wcコマンドのプログラムを作成

※以前のプラクティスでまだマージされていないものがあるため、`Files Changed`にwcコマンドのファイル以外の差分が出てしまっております。
当初導入されていなかった`rubocop-fijord`により`fizzbuzz` プログラムのファイルが変更されておりますが、それ以外に手を加えた箇所はございません。

#### rubocop-fijord実行結果

<img width="434" alt="スクリーンショット 2021-09-13 16 47 10" src="https://user-images.githubusercontent.com/70847530/133044329-b1df960e-2983-41e8-b9bf-2f10e009e7c0.png">


<br>

## 動作確認方法
以下のコマンドを実行し、ローカルリポジトリへ複製してください。
```
$ git clone https://github.com/Hannosuke/ruby-practices.git
$ cd ruby-practices
$ git checkout wc
```
（リモートブランチ `wc ` がない場合、`$ git fetch origin`を実行してください）
<br>

- 標準入力から実行ができること
```ruby
% ruby 06.wc/wc.rb Gemfile

7 14 126 Gemfile
```
- `-l`オプションで、行数のみ表示ができること
```ruby
% ruby 06.wc/wc.rb -l Gemfile

7 Gemfile
```
- 引数にファイル名が複数個来た場合、以下のような表示ができること
```ruby
% ruby 06.wc/wc.rb Gemfile README.md 

7 14 126 Gemfile
41 69 2336 README.md
48 83 2462 total
```
- 自作の`ls -l`コマンドと、自作の`wc`コマンドをつなげた出力ができること
```ruby
% ruby 05.ls/ls.rb -l | ruby 06.wc/wc.rb   

14 119 759


# 本物のls-lコマンドとwcコマンドでの実行結果
% ls -l | wc

      14     119     784  # 本物のバイト数の方が多く表示されておりますが、ここがマルチバイト文字による差異かと考えました
```
- つなげた上で、`wc`コマンドでも`-l`オプションが機能すること
```ruby
% ruby 05.ls/ls.rb -l | ruby 06.wc/wc.rb -l

14
```

<br>

以上でご確認いただけます。
もし動作しないことがありましたら、ご連絡いただけますと幸いです。
よろしくお願いいたします。